### PR TITLE
Ability to add additional RBAC role rules.

### DIFF
--- a/templates/tonic-rbac.yaml
+++ b/templates/tonic-rbac.yaml
@@ -8,6 +8,11 @@ rules:
 - apiGroups: ["", "extensions", "apps"]
   resources: ["pods", "pods/log", "deployments", "replicasets", "secrets"]
   verbs: ["get", "list", "patch", "delete", "update"]
+{{- if ((.Values.tonicai).rbac).additionalRules }}
+{{- with .Values.tonicai.rbac.additionalRules }}
+{{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -109,6 +109,10 @@ tonicai:
   #  host: null
   #  labels: {}
 
+  # Additional role rules can be specified here, if necessary
+  #rbac:
+  #  additionalRules:
+
 # Deployment Strategy: This can be set to either "RollingUpdate" or "Recreate".  If not provided, the default value
 # is "RollingUpdate".  "RollingUpdate" will perform a rolling update of the deployment similar to a blue/green
 # deployment and thus requires additional resources as both old and new versions will be running silmultaneously


### PR DESCRIPTION
We use a pod security policy, so we need to be able to specify it.

An alternative approach would be to add the ability to specify a different role name and define it externally, but this would be more disruptive to the upstream and lead to drift with upstream changes.