### PR TITLE
Improve Ingress More

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,6 +3,6 @@ name: tonic
 description: A Helm chart for Tonic and EKS
 type: application
 
-version: "1.0.2-r1"
+version: "1.0.2-r2"
 
 appVersion: "130"

--- a/templates/tonic-web-server-ingress.yaml
+++ b/templates/tonic-web-server-ingress.yaml
@@ -5,8 +5,12 @@ kind: Ingress
 metadata:
   name: tonic-web-server-ingress
   namespace: {{ .Release.Namespace }}
+  {{- if ((.Values.tonicai.ingress).annotations }}
   annotations:
-    kubernetes.io/ingress.class: {{ default "nginx" .Values.tonicai.ingress.class | quote }}
+    {{- toYaml .Values.tonicai.ingress.annotations | nindent 4 }}
+  {{- else }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/service-upstream: "true"
@@ -14,6 +18,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
     nginx.ingress.kubernetes.io/proxy-body-size: "0" # disable body size constraint
+  {{- end }}
   {{- if .Values.tonicai.ingress.labels }}
   labels:
     {{- with .Values.tonicai.ingress.labels }}

--- a/values.sample.yaml
+++ b/values.sample.yaml
@@ -108,6 +108,9 @@ tonicai:
   #  class: nginx
   #  host: null
   #  labels: {}
+  # By default this chart will create an nginx ingress, however providing
+  # additional annotations will disable this
+  #  annotations: {}
 
 # Deployment Strategy: This can be set to either "RollingUpdate" or "Recreate".  If not provided, the default value
 # is "RollingUpdate".  "RollingUpdate" will perform a rolling update of the deployment similar to a blue/green


### PR DESCRIPTION
Allow wholesale replacement of ingress annotations, in the style of the web server service.

This will allow us to properly configure Traefik.